### PR TITLE
fix: allow ci to pass with no tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "biome check src/",
     "format": "biome format --write src/",
     "lint:fix": "biome check --apply src/",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change modifies the `test` script to allow Jest to pass even when no tests are found.

Changes to `package.json`:

* Modified the `test` script to use `jest --passWithNoTests` instead of just `jest`.