### PR TITLE
Apply tests on alpha and beta branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - alpha
+      - beta
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to expand the branches that trigger the workflow.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR7-R8): Added `alpha` and `beta` branches to the list of branches that trigger the CI workflow under the `pull_request` event.