### PR TITLE
fix error in diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ graph TD
 
     subgraph "Agent Forge Core"
         AF[AgentForge Instance]
-        LLM[LLM Provider (via token.js)]
+        LLM["LLM Provider (via token.js)"]
         YAML[Agent YAML Definitions]
         TR[ToolRegistry]
         MCPMgr[MCPManager]


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change adjusts the formatting of the `LLM` node in the `graph TD` diagram by enclosing its label in quotes for consistency.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64): Updated the `LLM` node label in the `graph TD` diagram to include quotes, ensuring consistent formatting across the diagram.