### PR TITLE
add anonymous visitor tracking on documentation pages

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -28,6 +28,17 @@ const config: Config = {
     locales: ["en"],
   },
 
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {
+        defer: "true",
+        src: "https://data.frostlogic.se/script.js",
+        "data-website-id": "05311cfd-53ca-4094-8cf2-6e6e8712e9b9",
+      },
+    },
+  ],
+
   presets: [
     [
       "classic",


### PR DESCRIPTION
This pull request adds a new configuration to the Docusaurus configuration file, enabling the inclusion of a custom script for analytics.

Configuration changes:

* [`docs/docusaurus.config.ts`](diffhunk://#diff-9dbe126a5a498e56dcf30f25d7fc163f8443517db03458905d3d33303e1cdbf9R31-R41): Added a `headTags` property to include a script tag for analytics, specifying the script source URL, a `defer` attribute, and a `data-website-id` for tracking purposes.