### PR TITLE
remove documentation from triggering a release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
         "labels": {
           "feature": "minor",
           "enhancement": "minor",
-          "documentation": "patch",
+
           "bug": "patch",
           "fix": "patch",
           "breaking": "major"


### PR DESCRIPTION
This pull request includes a small change to the `.releaserc.json` file. The change removes the `"documentation": "patch"` label from the configuration.