### PR TITLE
fix an issue where a rate limited request will not restart after timer

### DIFF
--- a/src/tools/mcp-tool.ts
+++ b/src/tools/mcp-tool.ts
@@ -748,6 +748,16 @@ export class MCPManager {
    * Closes all MCP connections
    */
   async close(): Promise<void> {
+    // Clean up rate limiters
+    if (this.globalRateLimiter) {
+      this.globalRateLimiter.cleanup();
+    }
+
+    for (const rateLimiter of this.rateLimiters.values()) {
+      rateLimiter.cleanup();
+    }
+
+    // Close all clients
     for (const client of this.clients) {
       await client.close();
     }

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -13,6 +13,7 @@ export class RateLimiter {
   private intervalMs: number;
   private maxTokens: number;
   private toolName: string;
+  private resetTimer: NodeJS.Timeout | null = null;
 
   constructor(options: RateLimiterOptions) {
     this.options = options;
@@ -33,6 +34,72 @@ export class RateLimiter {
     this.tokensRemaining = this.maxTokens;
     this.lastResetTime = Date.now();
     this.toolName = options.toolName || "Unknown";
+  }
+
+  private scheduleTokenReset() {
+    if (this.resetTimer) {
+      clearTimeout(this.resetTimer);
+    }
+
+    // Calculate time until next reset
+    const now = Date.now();
+    const timeSinceReset = now - this.lastResetTime;
+    const timeUntilReset = Math.max(0, this.intervalMs - timeSinceReset);
+
+    // Schedule the reset
+    this.resetTimer = setTimeout(() => {
+      this.resetTokensAndProcessQueue();
+
+      // If there are still items in the queue, schedule another reset
+      if (this.waitingQueue.length > 0) {
+        this.scheduleTokenReset();
+      } else {
+        this.resetTimer = null;
+      }
+    }, timeUntilReset);
+  }
+
+  private resetTokensAndProcessQueue() {
+    const now = Date.now();
+    const timeSinceReset = now - this.lastResetTime;
+    const toolInfo = this.options.toolName ? `[${this.options.toolName}]` : "";
+
+    // Only reset if enough time has passed
+    if (timeSinceReset >= this.intervalMs) {
+      const resetCount = Math.floor(timeSinceReset / this.intervalMs);
+      this.lastResetTime += resetCount * this.intervalMs;
+
+      // Add tokens, but don't exceed max
+      const tokensToAdd = resetCount * this.maxTokens;
+      this.tokensRemaining = Math.min(
+        this.maxTokens,
+        this.tokensRemaining + tokensToAdd
+      );
+
+      if (this.options.verbose) {
+        console.log(
+          `${toolInfo} Rate limit reset. ${this.tokensRemaining} tokens available.`
+        );
+      }
+
+      // Process waiting queue if tokens are available
+      this.processWaitingQueue(toolInfo);
+    }
+  }
+
+  private processWaitingQueue(toolInfo: string) {
+    while (this.tokensRemaining > 0 && this.waitingQueue.length > 0) {
+      const resolve = this.waitingQueue.shift();
+      if (resolve) {
+        this.tokensRemaining--; // Consume token for queued item
+        if (this.options.verbose) {
+          console.log(
+            `${toolInfo} Token granted to queued request. ${this.tokensRemaining}/${this.maxTokens} tokens remaining.`
+          );
+        }
+        resolve();
+      }
+    }
   }
 
   public async waitForToken(): Promise<void> {
@@ -59,18 +126,7 @@ export class RateLimiter {
       }
 
       // Process waiting queue if tokens are available
-      while (this.tokensRemaining > 0 && this.waitingQueue.length > 0) {
-        const resolve = this.waitingQueue.shift();
-        if (resolve) {
-          this.tokensRemaining--; // Consume token for queued item
-          if (this.options.verbose) {
-            console.log(
-              `${toolInfo} Token granted to queued request. ${this.tokensRemaining}/${this.maxTokens} tokens remaining.`
-            );
-          }
-          resolve();
-        }
-      }
+      this.processWaitingQueue(toolInfo);
     }
 
     // If we have tokens available, use one and proceed
@@ -100,6 +156,11 @@ export class RateLimiter {
       );
     }
 
+    // Schedule token reset if not already scheduled
+    if (!this.resetTimer && this.waitingQueue.length === 0) {
+      this.scheduleTokenReset();
+    }
+
     await new Promise<void>((resolve) => {
       this.waitingQueue.push(resolve);
     });
@@ -108,6 +169,37 @@ export class RateLimiter {
       console.log(
         `${toolInfo} Token received after waiting, continuing execution.`
       );
+    }
+  }
+
+  /**
+   * Cleans up resources used by the rate limiter
+   * Should be called when the rate limiter is no longer needed
+   */
+  public cleanup(): void {
+    if (this.resetTimer) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
+
+    // Clear any waiting requests to prevent memory leaks
+    if (this.waitingQueue.length > 0) {
+      const toolInfo = this.options.toolName
+        ? `[${this.options.toolName}]`
+        : "";
+      if (this.options.verbose) {
+        console.log(
+          `${toolInfo} Cleaning up rate limiter with ${this.waitingQueue.length} waiting requests`
+        );
+      }
+
+      // Resolve all waiting promises to prevent hanging
+      while (this.waitingQueue.length > 0) {
+        const resolve = this.waitingQueue.shift();
+        if (resolve) {
+          resolve();
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to the rate limiter functionality and enhances resource cleanup in the MCP tool. Key changes include adding a cleanup mechanism for rate limiters, improving token reset scheduling, and ensuring proper handling of waiting requests to prevent memory leaks.

### Enhancements to Rate Limiter (`src/utils/rate-limiter.ts`):

* Added a `cleanup` method to the `RateLimiter` class to clear timers and resolve all pending requests, preventing memory leaks.
* Introduced a `scheduleTokenReset` method to handle token replenishment at regular intervals, ensuring smooth queue processing. [[1]](diffhunk://#diff-50e1b283aee235f889fba91fe1772667697e3e8f9f2db89a1e9845314502438bL38-R67) [[2]](diffhunk://#diff-50e1b283aee235f889fba91fe1772667697e3e8f9f2db89a1e9845314502438bR159-R163)
* Refactored token reset logic into `resetTokensAndProcessQueue` and `processWaitingQueue` methods for better modularity and readability. [[1]](diffhunk://#diff-50e1b283aee235f889fba91fe1772667697e3e8f9f2db89a1e9845314502438bL38-R67) [[2]](diffhunk://#diff-50e1b283aee235f889fba91fe1772667697e3e8f9f2db89a1e9845314502438bR86-R90)
* Updated `waitForToken` to integrate the new scheduling and queue processing logic, ensuring tokens are reset efficiently.

### Resource Cleanup in MCP Tool (`src/tools/mcp-tool.ts`):

* Enhanced the `close` method in `MCPManager` to call the `cleanup` method of all rate limiters, ensuring proper resource deallocation.