### PR TITLE
fix exports of a2a types and classes

### DIFF
--- a/src/a2a/index.ts
+++ b/src/a2a/index.ts
@@ -1,4 +1,9 @@
 export * from "./common/A2AProtocol";
 export * from "./common/types";
 export { A2AServer, defaultAgentToTaskHandlerAdapter } from "./server";
+export type {
+  A2AServerOptions,
+  A2ATaskHandler,
+  AgentToTaskHandlerAdapter,
+} from "./server";
 export * from "./client"; // This will export from src/a2a/client/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,26 @@ export { Team } from "./core/team";
 export { loadAgentFromYaml } from "./config/yaml-loader";
 export { AgentForge } from "./core/agent-forge";
 
-// A2A Protocol exports (New Addition)
-export * as A2A from "./a2a";
+// A2A Protocol exports
+export {
+  A2AServer,
+  defaultAgentToTaskHandlerAdapter,
+  A2AClient,
+  RemoteA2AAgent,
+} from "./a2a";
+export type {
+  A2AClientOptions,
+  A2AServerOptions,
+  A2ATaskHandler,
+  AgentToTaskHandlerAdapter,
+  A2AAgentCard,
+  A2ATask,
+  A2AMessage,
+  A2AStreamEvent,
+  A2ATaskSendParams,
+  A2ATaskGetParams,
+  A2ATaskCancelParams,
+} from "./a2a";
 
 // Tool system exports
 export { Tool } from "./tools/tool";


### PR DESCRIPTION
This pull request refines the exports for the A2A (Agent-to-Agent) protocol by consolidating and expanding the available types and components. The changes aim to improve the clarity and usability of the A2A module for developers integrating it into their projects.

### A2A Protocol Export Enhancements:

* [`src/a2a/index.ts`](diffhunk://#diff-d16f974f6347e98a38d0380f8c5ab165a119f1052add785b7c49778f1af29b4bR4-R8): Added explicit type exports for `A2AServerOptions`, `A2ATaskHandler`, and `AgentToTaskHandlerAdapter` to ensure these types are directly available for import.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L12-R31): Reorganized and expanded the A2A exports to include both key components (`A2AServer`, `A2AClient`, etc.) and associated types (`A2AClientOptions`, `A2ATask`, `A2AMessage`, etc.), providing a more comprehensive and structured export interface.