### PR TITLE
accept any type for addAgent to accept classes that extend Agent

### DIFF
--- a/src/core/team.ts
+++ b/src/core/team.ts
@@ -4,11 +4,10 @@ import {
   type Task,
   type TeamRunOptions,
 } from "../types";
-import { Visualizer } from "../utils/decorators";
 import { globalEventEmitter } from "../utils/event-emitter";
 import { RateLimiter } from "../utils/rate-limiter";
 import { enableConsoleStreaming } from "../utils/streaming";
-import type { Agent, AgentRunOptions } from "./agent";
+import { Agent, type AgentRunOptions } from "./agent";
 import { AgentInteractionHelper } from "./team/agent-interaction-helper";
 import { ManagerResponseParser } from "./team/manager-response-parser";
 import { TaskExecutor } from "./team/task-executor";
@@ -99,21 +98,31 @@ export class Team {
 
   /**
    * Adds an agent to the team
-   * @param agent The agent to add
+   * @param agent The agent to add must be an instance of Agent class or extend Agent class
    * @returns The team instance for method chaining
    */
-  addAgent(agent: Agent): Team {
+  addAgent(agent: any): Team {
+    if (!(agent instanceof Agent)) {
+      throw new Error(
+        "Agent must be an instance of Agent class or extend Agent class"
+      );
+    }
     this.agents.set(agent.name, agent);
     return this;
   }
 
   /**
    * Adds multiple agents to the team
-   * @param agents The agents to add
+   * @param agents The agents to add must be an instance of Agent class or extend Agent class
    * @returns The team instance for method chaining
    */
-  addAgents(agents: Agent[]): Team {
+  addAgents(agents: any[]): Team {
     for (const agent of agents) {
+      if (!(agent instanceof Agent)) {
+        throw new Error(
+          "Agent must be an instance of Agent class or extend Agent class"
+        );
+      }
       this.addAgent(agent);
     }
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,12 @@ export { WebPageContentTool } from "./tools/web-page-content-tool";
 export {
   MCPClientWrapper,
   MCPSdkClientWrapper,
-  MCPTool,
   createMCPClient,
   MCPToolWrapper,
   MCPManager,
   MCPProtocolType,
 } from "./tools/mcp-tool";
+export type { MCPTool } from "./tools/mcp-tool";
 
 // LLM provider exports
 export { LLM } from "./llm/llm";


### PR DESCRIPTION
This pull request introduces changes to improve type safety and code clarity in the `src/core/team.ts` file and adjusts exports in the `src/index.ts` file. The most important changes include stricter type checks for agent-related methods in the `Team` class and modifications to the way types and classes are imported and exported.

### Type Safety Improvements:
* **`addAgent` and `addAgents` methods in `src/core/team.ts`:** Added runtime checks to ensure that agents passed to these methods are instances of the `Agent` class or extend it. This prevents invalid objects from being added to the team.

### Import and Export Adjustments:
* **Imports in `src/core/team.ts`:** Removed unused `Visualizer` import and updated the `Agent` import to combine type and class imports for better readability.
* **Exports in `src/index.ts`:** Changed the export of `MCPTool` to a type-only export to streamline the module interface.