### PR TITLE
Adds new A2A client options to customize the number of retries to get the status

### DIFF
--- a/src/a2a/client/types.ts
+++ b/src/a2a/client/types.ts
@@ -1,7 +1,8 @@
 export interface A2AClientOptions {
   serverUrl: string; // Base URL of the A2A agent server (e.g., "http://localhost:41241/a2a")
   fetch?: typeof fetch; // Optional custom fetch implementation (for Node.js or specific environments)
-  // Optional: custom logger, default request headers, etc.
+  taskStatusRetries?: number; // Number of retries to get task status
+  taskStatusRetryDelay?: number; // Delay between retries in milliseconds
 }
 
 export interface A2AClientSubscription {

--- a/src/a2a/decorators.ts
+++ b/src/a2a/decorators.ts
@@ -1,12 +1,9 @@
-import type { ConfigOptions } from "token.js";
 import type { Agent } from "../core/agent";
 import { LLM } from "../llm/llm";
-import type { LLMProvider } from "../types";
 import { RemoteA2AAgent } from "./client/RemoteA2AAgent";
 import type { A2AClientOptions } from "./client/types";
 import { A2AServer } from "./server/A2AServer";
 import type { A2AServerOptions } from "./server/types";
-// import { agent } from "../core/decorators"; // If you want to re-export
 
 /**
  * Class decorator to make an Agent class use a remote A2A agent via the A2A protocol.

--- a/src/core/team.ts
+++ b/src/core/team.ts
@@ -380,7 +380,11 @@ ${TASK_FORMAT_PROMPT}
     conversationHistory: string[]
   ): Promise<string> {
     // Get the initial plan from the manager
-    const managerResult = await this.manager.run(managerPrompt);
+    const managerResult = await this.manager.run(managerPrompt, {
+      maxTurns: this.options?.maxTurns,
+      maxExecutionTime: this.options?.maxExecutionTime,
+      stream: this.options?.stream,
+    });
     conversationHistory.push(`Manager: ${managerResult.output}`);
 
     // Try to extract initial assignments or get explicit ones
@@ -423,7 +427,11 @@ ${TASK_FORMAT_PROMPT}
         // If changes were made, give manager feedback
         const changeReport =
           this.teamReporter.generateTaskChangeReport(taskChanges);
-        const changesResult = await this.manager.run(changeReport);
+        const changesResult = await this.manager.run(changeReport, {
+          maxTurns: this.options?.maxTurns,
+          maxExecutionTime: this.options?.maxExecutionTime,
+          stream: this.options?.stream,
+        });
         currentManagerResponse = changesResult.output;
         conversationHistory.push(
           `Manager (Changes): ${currentManagerResponse}`

--- a/src/core/team/task-executor.ts
+++ b/src/core/team/task-executor.ts
@@ -89,6 +89,8 @@ export class TaskExecutor {
     try {
       const agentResult = await agent.run(formattedTask, {
         stream: this.stream,
+        maxTurns: this.options?.maxTurns,
+        maxExecutionTime: this.options?.maxExecutionTime,
       });
 
       if (this.teamRunLogger) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,6 +214,16 @@ export interface TeamRunOptions {
    * Only applicable when stream is true
    */
   enableConsoleStream?: boolean;
+
+  /**
+   * Maximum number of turns to run
+   */
+  maxTurns?: number;
+
+  /**
+   * Maximum execution time in milliseconds (default: 2 minutes)
+   */
+  maxExecutionTime?: number;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces enhancements to the retry logic for task status checks in the `RemoteA2AAgent` class and adds new configuration options for task execution limits across multiple components. Key changes include introducing configurable retry parameters, extending task execution options, and cleaning up unused imports.

### Enhancements to Retry Logic in `RemoteA2AAgent`:

* [`src/a2a/client/RemoteA2AAgent.ts`](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083R38-R39): Added `taskStatusRetries` and `taskStatusRetryDelay` as configurable parameters to control the number of retries and delay between retries for task status checks. Default values are set to 10 retries and 1000 milliseconds, respectively. These parameters are used in the retry loop for task status updates. [[1]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083R38-R39) [[2]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083R51-R52) [[3]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L162-R166) [[4]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L181-R187)
* [`src/a2a/client/types.ts`](diffhunk://#diff-9b952df4309259ff0af463864fc069363d159cdde160bdf536ded4d643c76d87L4-R5): Updated `A2AClientOptions` to include `taskStatusRetries` and `taskStatusRetryDelay` as optional fields.

### Extensions to Task Execution Options:

* [`src/core/team.ts`](diffhunk://#diff-1b991361d100776488d0119abccf44b111b2a4ab59535186b361f4026c492e5eL383-R387): Updated calls to the `manager.run` method to include additional options (`maxTurns`, `maxExecutionTime`, and `stream`) for better control over task execution limits. [[1]](diffhunk://#diff-1b991361d100776488d0119abccf44b111b2a4ab59535186b361f4026c492e5eL383-R387) [[2]](diffhunk://#diff-1b991361d100776488d0119abccf44b111b2a4ab59535186b361f4026c492e5eL426-R434)
* [`src/core/team/task-executor.ts`](diffhunk://#diff-0efbe8cb6b6423ed86928cda87a4351f2e70050da61ad74a8056cffb756ac1f4R92-R93): Added support for `maxTurns` and `maxExecutionTime` in the `TaskExecutor` class to align with the new task execution options.
* [`src/types/index.ts`](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R217-R226): Introduced `maxTurns` and `maxExecutionTime` fields in the `TeamRunOptions` interface to define execution limits for tasks.

### Code Cleanup:

* [`src/a2a/decorators.ts`](diffhunk://#diff-ebcd0718aa5bead65cf9197421d48f77863549164a3a5dd5d14a61f855488c01L1-L9): Removed unused imports to tidy up the codebase.