### PR TITLE
Fixes a issue when remote A2A agent is in streaming mode, final result wasn't delivered

### DIFF
--- a/src/a2a/client/RemoteA2AAgent.ts
+++ b/src/a2a/client/RemoteA2AAgent.ts
@@ -111,7 +111,7 @@ export class RemoteA2AAgent extends Agent {
           stream: true, // Explicitly enable streaming for the task creation
         };
         // Ensure the task is created on the server with streaming enabled
-        const initialTask = await this.a2aClient.sendTask(
+        const initialTask: A2ATaskSendResult = await this.a2aClient.sendTask(
           streamingTaskSendParams
         );
         if (!initialTask || !initialTask.id) {
@@ -119,6 +119,10 @@ export class RemoteA2AAgent extends Agent {
             "Failed to send task (with streaming) to remote agent or received invalid response."
           );
         }
+
+        // Track whether we received a final output artifact
+        let finalOutputFromArtifact = "";
+        let hasReceivedFinalOutput = false;
 
         // Now subscribe to the events for the task ID
         const stream = this.a2aClient.sendTaskSubscribe(
@@ -130,15 +134,24 @@ export class RemoteA2AAgent extends Agent {
               "Remote agent task cancelled by client during stream."
             );
           }
-          this.processA2AEvent(event, toolCalls, (chunk) => {
-            accumulatedLlmResponseForAgentResult += chunk;
-            globalEventEmitter.emit(AgentForgeEvents.LLM_STREAM_CHUNK, {
-              agentName: this.name,
-              chunk: chunk,
-              isDelta: true,
-              isComplete: false,
-            } as LLMStreamEvent);
-          });
+          this.processA2AEvent(
+            event,
+            toolCalls,
+            (chunk) => {
+              accumulatedLlmResponseForAgentResult += chunk;
+              globalEventEmitter.emit(AgentForgeEvents.LLM_STREAM_CHUNK, {
+                agentName: this.name,
+                chunk: chunk,
+                isDelta: true,
+                isComplete: false,
+              } as LLMStreamEvent);
+            },
+            (finalOutput) => {
+              // Callback for when we receive final output artifact
+              finalOutputFromArtifact = finalOutput;
+              hasReceivedFinalOutput = true;
+            }
+          );
           if (
             (event as A2ATaskStatusUpdateEvent).final ||
             (event as A2ATaskErrorEvent).final
@@ -151,17 +164,22 @@ export class RemoteA2AAgent extends Agent {
             break;
           }
         }
-        finalOutput = accumulatedLlmResponseForAgentResult;
+
+        // Prefer final output from artifact if available, otherwise use accumulated response
+        finalOutput = hasReceivedFinalOutput
+          ? finalOutputFromArtifact
+          : accumulatedLlmResponseForAgentResult;
       } else {
         // Non-streaming: send task without stream flag (or stream:false implicitly)
-        const initialTask = await this.a2aClient.sendTask(baseTaskSendParams);
+        const initialTask: A2ATaskSendResult =
+          await this.a2aClient.sendTask(baseTaskSendParams);
         if (!initialTask || !initialTask.id) {
           throw new Error(
             "Failed to send task to remote agent or received invalid response."
           );
         }
 
-        let currentTask: A2ATask | null = initialTask;
+        let currentTask: A2ATaskGetResult = initialTask;
         let attempts = 0;
         const maxAttempts = this.taskStatusRetries;
 
@@ -171,7 +189,8 @@ export class RemoteA2AAgent extends Agent {
               "Remote agent task cancelled by client during polling."
             );
           }
-          currentTask = await this.a2aClient.getTask({ id: taskId });
+          const getParams: A2ATaskGetParams = { id: taskId };
+          currentTask = await this.a2aClient.getTask(getParams);
           if (!currentTask)
             throw new Error("Failed to get task status from remote agent.");
 
@@ -289,7 +308,8 @@ export class RemoteA2AAgent extends Agent {
   private processA2AEvent(
     event: A2AStreamEvent,
     toolCalls: ToolCall[], // Allow modification
-    emitChunk: (chunk: string) => void
+    emitChunk: (chunk: string) => void,
+    emitFinalOutput?: (finalOutput: string) => void
   ) {
     if ("status" in event) {
       const statusEvent = event as A2ATaskStatusUpdateEvent;
@@ -324,9 +344,23 @@ export class RemoteA2AAgent extends Agent {
             e
           );
         }
+      } else if (
+        artifactEvent.artifact.name === "final_output.txt" ||
+        (artifactEvent.artifact.mimeType === "text/plain" &&
+          artifactEvent.artifact.name?.includes("final"))
+      ) {
+        // Handle final output artifacts by emitting their content as chunks
+        const finalContent = artifactEvent.artifact.parts
+          .map((p) => p.text)
+          .join("");
+        if (finalContent) {
+          emitChunk(finalContent);
+          if (emitFinalOutput) {
+            emitFinalOutput(finalContent);
+          }
+        }
       }
-      // Other artifacts, like final_output, are typically handled by polling logic
-      // or a specific final event, not streamed as LLM chunks.
+      // Other artifacts are handled above or can be ignored for streaming
     }
   }
 }


### PR DESCRIPTION
This pull request enhances the `RemoteA2AAgent` class to improve handling of task streaming and final output artifacts. Key updates include introducing a mechanism to track and prioritize final output artifacts, refining type annotations for better clarity, and extending the `processA2AEvent` method to handle final output more effectively.

### Enhancements to task streaming and final output handling:

* Introduced tracking for final output artifacts using new variables `finalOutputFromArtifact` and `hasReceivedFinalOutput`, ensuring the final output is prioritized over accumulated responses when available. [[1]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083R123-R126) [[2]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L154-R182)
* Updated the `processA2AEvent` method to include an optional `emitFinalOutput` callback, enabling the handling of final output artifacts during event processing.
* Added logic to process and emit content from final output artifacts (e.g., `final_output.txt`) as chunks, ensuring they are integrated seamlessly into the streaming workflow.

### Type improvements for clarity and correctness:

* Added explicit type annotations for `initialTask` and `currentTask` variables to improve type safety and readability. [[1]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L114-R114) [[2]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L154-R182) [[3]](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083L174-R193)