### PR TITLE
show helpful error when timeout of running remote agent is reached

### DIFF
--- a/src/a2a/client/RemoteA2AAgent.ts
+++ b/src/a2a/client/RemoteA2AAgent.ts
@@ -222,8 +222,15 @@ export class RemoteA2AAgent extends Agent {
           );
         }
         if (currentTask.status.state !== A2ATaskStates.COMPLETED) {
+          if (attempts >= maxAttempts) {
+            const timeoutSeconds =
+              (this.taskStatusRetryDelay * maxAttempts) / 1000;
+            throw new Error(
+              `Polling for remote agent task status timed out after ${maxAttempts} attempts (${timeoutSeconds}s). Final state: ${currentTask.status.state}`
+            );
+          }
           throw new Error(
-            `Remote agent task did not complete. Final state: ${currentTask.status.state}`
+            `Remote agent task did not complete for an unexpected reason. Final state: ${currentTask.status.state}`
           );
         }
 

--- a/src/examples/a2a-example/a2a-team-example.ts
+++ b/src/examples/a2a-example/a2a-team-example.ts
@@ -5,7 +5,9 @@ import { SummarizerAgent } from "./agents/summarizer.agent";
 import { RemoteHelpfulAssistant } from "./agents/remote.agent";
 import { AgentForge, readyForge } from "../../core/agent-forge";
 import { configuredProvider, configuredApiKey } from "./provider";
+import { Visualizer } from "../../";
 
+@Visualizer()
 @llmProvider(configuredProvider, { apiKey: configuredApiKey })
 @forge()
 class TeamExample {

--- a/src/examples/a2a-example/agents/remote.agent.ts
+++ b/src/examples/a2a-example/agents/remote.agent.ts
@@ -8,5 +8,5 @@ import { Agent } from "../../../core/agent";
  * @a2aClient({ serverUrl: "http://localhost:41241/a2a" })
  * class RemoteHelpfulAssistant extends Agent { ... }
  */
-@a2aClient({ serverUrl: "http://localhost:41241/a2a" })
+@a2aClient({ serverUrl: "http://localhost:41241/a2a", taskStatusRetries: 60 }, 'RemoteHelpfulAssistant')
 export class RemoteHelpfulAssistant extends Agent {}


### PR DESCRIPTION
This pull request introduces improvements to error handling, configuration flexibility, and visualization in the A2A agent framework. The most important changes include enhanced error messages for task polling timeouts, updated configuration options for the `RemoteHelpfulAssistant` agent, and the addition of a `Visualizer` decorator to the `TeamExample` class.

### Error Handling Improvements:
* [`src/a2a/client/RemoteA2AAgent.ts`](diffhunk://#diff-5339199bf854580bfa3f2bf44c00aaa5bbfc9392fe0b3dbeca011b3d2d641083R225-R233): Enhanced the error message for task polling timeouts to include the number of attempts and the total timeout duration in seconds. Also added a fallback error message for unexpected task completion issues.

### Configuration Enhancements:
* [`src/examples/a2a-example/agents/remote.agent.ts`](diffhunk://#diff-1f950f8860076c82adde9c5829fa0e4766110bf58b2f8a5e922a061d7e1c5871L11-R11): Updated the `@a2aClient` decorator for the `RemoteHelpfulAssistant` class to include a new `taskStatusRetries` option for configuring the number of retry attempts.

### Visualization Improvements:
* [`src/examples/a2a-example/a2a-team-example.ts`](diffhunk://#diff-bea6a53e99f4dadd226fac03c2711f4572e33c8cd2841303b48416ebcd55cd8fR8-R10): Introduced a `Visualizer` decorator to the `TeamExample` class to enable visualization capabilities.